### PR TITLE
Parse values with equal chars in urls

### DIFF
--- a/app/code/community/Payone/Core/Model/Domain/Protocol/Api.php
+++ b/app/code/community/Payone/Core/Model/Domain/Protocol/Api.php
@@ -123,7 +123,7 @@ class Payone_Core_Model_Domain_Protocol_Api extends Mage_Core_Model_Abstract
 
         $preparedData = array();
         foreach ($data as $key => $value) {
-            $valuearr = explode('=', $value);
+            $valuearr = explode('=', $value, 2);
             if (isset($valuearr[1]) && $valuearr[1] !=='') {
                 $preparedData[$valuearr[0]] = $valuearr[1];
             }


### PR DESCRIPTION
redirecturl=https://www.paypal.com/webscr?useraction=commit&cmd=_express-checkout&token=123456789
will be parsed to
redirecturl=https://www.paypal.com/webscr?useraction=
without this fix