### PR TITLE
Changed JavaScript initialization in checkout

### DIFF
--- a/app/design/frontend/base/default/template/payone/core/checkout/onepage/init.phtml
+++ b/app/design/frontend/base/default/template/payone/core/checkout/onepage/init.phtml
@@ -27,7 +27,7 @@
             new PAYONE.Handler.CreditCardCheck.OnepageCheckout()
     );
 
-    Event.observe(window, 'load', function () {
+    document.observe('dom:loaded', function () {
         payone.form = payment.form;
         payment.save = payment.save.wrap(
                 function (origMethod) {


### PR DESCRIPTION
We've experienced an error in checkout with the message "Payment method configuration with id "" not found." for some customers. After long time debugging this problem, I've possibly found the reason.

It seemed that the wrapper function for `payment.save` is never called for some customers, so PAYONE functionality is not executed. The form in checkout payment step is not getting validated and hidden fields are not filled with correct data (like the payment config id mentioned in the error message). The customer reaches checkout review though and gets the above error, when clicking on "Buy" (maybe the missing config id can be validated in observer method `importDataBefore` as well).

After changing the JavaScript observer in this file, we didn't get this error again. I do not understand this behaviour completely, but it seems to solve the problem. Referring to [prototype documentation](http://api.prototypejs.org/dom/document/observe/) `dom:loaded` should be the better way though. Magento also uses `dom:ready` in most cases. Maybe someone can understand.