### PR TITLE
Update mysql4-upgrade-3.0.3-3.0.4.php

### DIFF
--- a/app/code/community/Payone/Core/sql/payone_core_setup/mysql4-upgrade-3.0.3-3.0.4.php
+++ b/app/code/community/Payone/Core/sql/payone_core_setup/mysql4-upgrade-3.0.3-3.0.4.php
@@ -25,6 +25,9 @@
 /** @var $installer Mage_Core_Model_Resource_Setup */
 
 $installer = $this;
+if(false === Mage::getConfig()->getModuleConfig('Mage_AdminNotification')->is('active', 'true')){
+    return $this;
+}
 $installer->startSetup();
 
 // German Description


### PR DESCRIPTION
Many customers have the Module disabled and the setup will fail because of the missing tables.