### PR TITLE
Update mysql4-upgrade-3.0.8-3.0.9.php

### DIFF
--- a/app/code/community/Payone/Core/sql/payone_core_setup/mysql4-upgrade-3.0.8-3.0.9.php
+++ b/app/code/community/Payone/Core/sql/payone_core_setup/mysql4-upgrade-3.0.8-3.0.9.php
@@ -25,6 +25,9 @@
 /** @var $installer Mage_Core_Model_Resource_Setup */
 
 $installer = $this;
+if(false === Mage::getConfig()->getModuleConfig('Mage_AdminNotification')->is('active', 'true')){
+    return $this;
+}
 $installer->startSetup();
 
 /** @var $helper Payone_Core_Helper_Data */


### PR DESCRIPTION
Some Customers have the Module Mage_AdminNotification disabled and the setup fails because of the missing module