### PR TITLE
Update Abstract.php

### DIFF
--- a/app/code/community/Payone/Core/Model/Mapper/ApiRequest/Payment/Authorize/Abstract.php
+++ b/app/code/community/Payone/Core/Model/Mapper/ApiRequest/Payment/Authorize/Abstract.php
@@ -330,7 +330,7 @@ abstract class Payone_Core_Model_Mapper_ApiRequest_Payment_Authorize_Abstract
 
         // Multiple Ips could be included, we only send the last one.
         $remoteIps = explode(',', $remoteIp);
-        $ip = array_pop($remoteIps);
+        $ip = array_shift($remoteIps);
         return $ip;
     }
 


### PR DESCRIPTION
Regarding RFC 7239 which says 
 A proxy server that wants to add a new "Forwarded" header field value
   can either append it to the last existing "Forwarded" header field
   after a comma separator or add a new field at the end of the header
   block.  A proxy MAY remove all "Forwarded" header fields from a
   request.  It MUST, however, ensure that the correct header field is
   updated in case of multiple "Forwarded" header fields.

so we have to take first element of the chain instead of the last one.