### PR TITLE
Adding default values to Invoicing Info non-product items (credit memo, shipping, discounts)

### DIFF
--- a/app/code/community/Payone/Core/etc/config.xml
+++ b/app/code/community/Payone/Core/etc/config.xml
@@ -784,6 +784,19 @@ Detaillierte Informationen zur Arbeitsweise der ABC finde ich unter www.abc.de/f
                 <enabled>0</enabled>
                 <template>payone_misc_email_avs_template</template>
             </email_avs>
+            <discount>
+                <sku>discount</sku>
+                <description>Discount</description>
+            </discount>
+            <creditmemo>
+                <adjustment_refund_sku>adjustment-refund</adjustment_refund_sku>
+                <adjustment_refund_name>Adjustment Refund</adjustment_refund_name>
+                <adjustment_fee_sku>adjustment-fee</adjustment_fee_sku>
+                <adjustment_fee_name>Adjustment Fee</adjustment_fee_name>
+            </creditmemo>
+            <shipping_costs>
+                <sku>shipping</sku>
+            </shipping_costs>
         </payone_misc>
     </default>
 


### PR DESCRIPTION
If these fields were left blank, the correct working of crucial parts of the payment flow - such as invoicing - were dependent on the translation system. At some points the translation might not be available - which might be the case for some API calls. It is best to leave this field filled up by default, and the most experienced user would then be able to tweak this if needed.