### PR TITLE
XForwardedFor Header can contain Whitespace.

### DIFF
--- a/app/code/community/Payone/Core/Model/Mapper/ApiRequest/Payment/Authorize/Abstract.php
+++ b/app/code/community/Payone/Core/Model/Mapper/ApiRequest/Payment/Authorize/Abstract.php
@@ -332,6 +332,8 @@ abstract class Payone_Core_Model_Mapper_ApiRequest_Payment_Authorize_Abstract
         // Multiple Ips could be included, we only send the last one.
         $remoteIps = explode(',', $remoteIp);
         $ip = array_shift($remoteIps);
+        // remove leading Whitespace for Muliple IPs e.g. "0.0.0.0, 1.1.1.1"
+        $ip = trim($ip);
         return $ip;
     }
 


### PR DESCRIPTION
This fix removes leading or trailing whitespaces in the XForwardedFor header.