### PR TITLE
MAGE-319 - Give 'PaymentMethodConfigNotFound' a more meaningful message

### DIFF
--- a/app/code/community/Payone/Core/Helper/Config.php
+++ b/app/code/community/Payone/Core/Helper/Config.php
@@ -136,7 +136,7 @@ class Payone_Core_Helper_Config
     {
         $configId = $order->getPayment()->getData('payone_config_payment_method_id');
         if (!$configId) {
-            $message = 'Payment method configuration with id "' . $configId . '" not found.';
+            $message = 'Payment method configuration for method "'. $order->getPayment()->getMethod() .'" not found.';
             throw new Payone_Core_Exception_PaymentMethodConfigNotFound($message);
         }
 
@@ -155,7 +155,7 @@ class Payone_Core_Helper_Config
     {
         $configId = $quote->getPayment()->getData('payone_config_payment_method_id');
         if (!$configId) {
-            $message = 'Payment method configuration with id "' . $configId . '" not found.';
+            $message = 'Payment method configuration for method "'. $quote->getPayment()->getMethod() .'" not found.';
             throw new Payone_Core_Exception_PaymentMethodConfigNotFound($message);
         }
 


### PR DESCRIPTION
When this exception is being thrown the variable `$configId` always contains a value that evaluates with `false` e.g. "0" or "" – So it makes more sense to print the method's name here to better help debugging purposes.