### PR TITLE
[MAGE-327] Display a notice and push state to browser history

### DIFF
--- a/app/code/community/Payone/Core/controllers/Checkout/CartController.php
+++ b/app/code/community/Payone/Core/controllers/Checkout/CartController.php
@@ -126,15 +126,17 @@ class Payone_Core_Checkout_CartController extends Mage_Checkout_CartController
                     $sMessage = $this->helper()->__('The Payone transaction has been canceled.');
                     $oOrder->addStatusHistoryComment($sMessage, Mage_Sales_Model_Order::STATE_CANCELED);
                     $oOrder->save();
+                    // Add a notice to Magento checkout and
+                    // prevent jumping forward in history:
+                    $sNotice = $this->helper()->__('The order has been canceled.');
+                    $oSession->setData('has_canceled_order_text', $sNotice);
+                    $oSession->setData('has_canceled_order', true);
+                    $oSession->addNotice($sNotice);
                 }
-
                 // Load quote
                 $oQuote = $this->getQuoteByCheckoutSession($oSession);
                 if ($oQuote) {
                     $this->reactivateQuote($oQuote);
-                    
-                    //reload the page
-                    $this->_redirect('checkout/cart');
                 }
             }
         }

--- a/app/design/frontend/base/default/layout/payone/core.xml
+++ b/app/design/frontend/base/default/layout/payone/core.xml
@@ -51,20 +51,21 @@
     </payone_core_pexpress_review>
 
     <checkout_cart_index>
+        <reference name="head">
+            <block type="core/template" name="payone_core_checkout_cart_helper" template="payone/core/checkout/cart/helper.phtml" />
+        </reference>
         <reference name="checkout.cart.top_methods">
             <block type="payone_core/paypal_express_shortcut" name="payone.checkout.cart.methods.paypal_express.top" before="-" template="payone/core/paypal/express/shortcut.phtml">
                 <action method="setIsQuoteAllowed"><value>1</value></action>
                 <action method="setShowOrPosition"><value>after</value></action>
             </block>
         </reference>
-
         <reference name="checkout.cart.methods">
             <block type="payone_core/paypal_express_shortcut" name="payone.checkout.cart.methods.paypal_express.bottom" before="-" template="payone/core/paypal/express/shortcut.phtml">
                 <action method="setIsQuoteAllowed"><value>1</value></action>
                 <action method="setShowOrPosition"><value>after</value></action>
             </block>
         </reference>
-
         <!--<update handle="SHORTCUT_popup" />-->
     </checkout_cart_index>
 

--- a/app/design/frontend/base/default/template/payone/core/checkout/cart/helper.phtml
+++ b/app/design/frontend/base/default/template/payone/core/checkout/cart/helper.phtml
@@ -1,0 +1,36 @@
+<?php
+/**
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the GNU General Public License (GPL 3)
+ * that is bundled with this package in the file LICENSE.txt
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade Payone_Core to newer
+ * versions in the future. If you wish to customize Payone_Core for your
+ * needs please refer to http://www.payone.de for more information.
+ *
+ * @category        Payone
+ * @package         design_frontend_base_default
+ * @subpackage      template
+ * @copyright       Copyright (c) 2017 <kontakt@fatchip.de> - www.fatchip.de
+ * @author          FATCHIP GmbH <kontakt@fatchip.de>
+ * @license         <http://www.gnu.org/licenses/> GNU General Public License (GPL 3)
+ * @link            http://www.fatchip.de
+ */
+?>
+<?php
+/** @var Mage_Core_Block_Template $this */
+/** @var Mage_Checkout_Model_Session $oSession */
+$oSession = Mage::getSingleton('checkout/session');
+if ($oSession->getData('has_canceled_order')) :
+    $oSession->unsetData('has_canceled_order');
+    $sTitle = $oSession->getData('has_canceled_order_text') ?: 'The order has been canceled.';
+?>
+<script type="text/javascript">
+    history.pushState(null, '<?php echo $sTitle ?>', window.location.href);
+</script>
+<?php
+endif;


### PR DESCRIPTION
When a user cancels an order by leaving the external payment provider's checkout (e.g. PayPal) using the browser's history navigation ("back"), the shopping cart now displays a corresponding notice and prevents the user from navigating "forward" again.