### PR TITLE
[MAGE-327] Fix browser navigation during checkout

### DIFF
--- a/app/code/community/Payone/Core/Model/Observer/Checkout/Onepage/Payment/External.php
+++ b/app/code/community/Payone/Core/Model/Observer/Checkout/Onepage/Payment/External.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the GNU General Public License (GPL 3)
+ * that is bundled with this package in the file LICENSE.txt
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade Payone_Core to newer
+ * versions in the future. If you wish to customize Payone_Core for your
+ * needs please refer to http://www.payone.de for more information.
+ *
+ * @category        Payone
+ * @package         Payone_Core_Model
+ * @subpackage      Observer
+ * @copyright       Copyright (c) 2012 <info@noovias.com> - www.noovias.com
+ * @author          Matthias Walter <info@noovias.com>
+ * @license         <http://www.gnu.org/licenses/> GNU General Public License (GPL 3)
+ * @link            http://www.noovias.com
+ */
+
+/**
+ *
+ * @category        Payone
+ * @package         Payone_Core_Model
+ * @subpackage      Observer
+ * @copyright       Copyright (c) 2017 <kontakt@fatchip.de> - www.fatchip.de
+ * @author          FATCHIP GmbH <kontakt@fatchip.de>
+ * @license         <http://www.gnu.org/licenses/> GNU General Public License (GPL 3)
+ * @link            http://www.fatchip.de
+ */
+class Payone_Core_Model_Observer_Checkout_Onepage_Payment_External extends Payone_Core_Model_Observer_Abstract
+{
+    /**
+     * @var Varien_Object
+     */
+    protected $settings = null;
+
+    /**
+     * @param Varien_Event_Observer $observer
+     */
+    public function maintainCheckoutSession(Varien_Event_Observer $observer)
+    {
+        /** @var Mage_Core_Controller_Varien_Action $controller */
+        $controller = $observer->getEvent()->getData('controller_action');
+        $actionName = $controller->getFullActionName();
+        if (false === stripos($actionName, 'payone_core_checkout_onepage_payment')) {
+            /** @var Mage_Checkout_Model_Session $oSession */
+            $oSession = Mage::getSingleton('checkout/session');
+            if ($oSession->getPayoneExternalCheckoutActive() === true) {
+                $oSession->unsPayoneExternalCheckoutActive();
+                // Load last order by ID
+                $orderId = $oSession->getLastOrderId();
+                $oOrder = $this->getFactory()->getModelSalesOrder();
+                $oOrder->load($orderId);
+                if ($oOrder) {
+                    // Cancel order and add history comment:
+                    if ($oOrder->canCancel()) {
+                        $oOrder->cancel();
+                        $sMessage = $this->helper()->__('The Payone transaction has been canceled.');
+                        $oOrder->addStatusHistoryComment($sMessage, Mage_Sales_Model_Order::STATE_CANCELED);
+                        $oOrder->save();
+                        // Add a notice to Magento checkout and
+                        // prevent jumping forward in history:
+                        $sNotice = $this->helper()->__('The order has been canceled.');
+                        $oSession->setData('has_canceled_order_text', $sNotice);
+                        $oSession->setData('has_canceled_order', true);
+                        $oSession->addNotice($sNotice);
+                        if (false === stripos($actionName, 'checkout_cart_index')) {
+                            $controller->setRedirectWithCookieCheck('checkout/cart/index');
+                        }
+                    }
+                    // Load quote
+                    $quoteId = $oSession->getLastQuoteId();
+                    $oQuote = $this->getFactory()->getModelSalesQuote();
+                    $oQuote->load($quoteId);
+                    if ($oQuote && $oQuote->getId()) {
+                        $oQuote->setIsActive(1)
+                            ->setReservedOrderId(null)
+                            ->save();
+                        /** @var Mage_Checkout_Model_Session $oSession */
+                        $oSession = Mage::getSingleton('checkout/session');
+                        $oSession->replaceQuote($oQuote)->unsetData('last_real_order_id');
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/code/community/Payone/Core/Model/Payment/Method/OnlineBankTransfer.php
+++ b/app/code/community/Payone/Core/Model/Payment/Method/OnlineBankTransfer.php
@@ -63,4 +63,14 @@ class Payone_Core_Model_Payment_Method_OnlineBankTransfer
 
         return $this->matchingConfigs;
     }
+
+    /**
+     * @param $redirectUrl
+     */
+    public function setRedirectUrl($redirectUrl)
+    {
+        $oSession = Mage::getSingleton('checkout/session');
+        $oSession->setPayoneExternalCheckoutActive(true);
+        $this->redirectUrl = $redirectUrl;
+    }
 }

--- a/app/code/community/Payone/Core/Model/Payment/Method/OnlineBankTransferBct.php
+++ b/app/code/community/Payone/Core/Model/Payment/Method/OnlineBankTransferBct.php
@@ -47,4 +47,14 @@ class Payone_Core_Model_Payment_Method_OnlineBankTransferBct extends Payone_Core
 
         return $this->matchingConfigs;
     }
+
+    /**
+     * @param $redirectUrl
+     */
+    public function setRedirectUrl($redirectUrl)
+    {
+        $oSession = Mage::getSingleton('checkout/session');
+        $oSession->setPayoneExternalCheckoutActive(true);
+        $this->redirectUrl = $redirectUrl;
+    }
 }

--- a/app/code/community/Payone/Core/Model/Payment/Method/OnlineBankTransferEps.php
+++ b/app/code/community/Payone/Core/Model/Payment/Method/OnlineBankTransferEps.php
@@ -63,4 +63,14 @@ class Payone_Core_Model_Payment_Method_OnlineBankTransferEps
 
         return $this->matchingConfigs;
     }
+
+    /**
+     * @param $redirectUrl
+     */
+    public function setRedirectUrl($redirectUrl)
+    {
+        $oSession = Mage::getSingleton('checkout/session');
+        $oSession->setPayoneExternalCheckoutActive(true);
+        $this->redirectUrl = $redirectUrl;
+    }
 }

--- a/app/code/community/Payone/Core/Model/Payment/Method/OnlineBankTransferGiropay.php
+++ b/app/code/community/Payone/Core/Model/Payment/Method/OnlineBankTransferGiropay.php
@@ -63,4 +63,14 @@ class Payone_Core_Model_Payment_Method_OnlineBankTransferGiropay
 
         return $this->matchingConfigs;
     }
+
+    /**
+     * @param $redirectUrl
+     */
+    public function setRedirectUrl($redirectUrl)
+    {
+        $oSession = Mage::getSingleton('checkout/session');
+        $oSession->setPayoneExternalCheckoutActive(true);
+        $this->redirectUrl = $redirectUrl;
+    }
 }

--- a/app/code/community/Payone/Core/Model/Payment/Method/OnlineBankTransferIdl.php
+++ b/app/code/community/Payone/Core/Model/Payment/Method/OnlineBankTransferIdl.php
@@ -63,4 +63,14 @@ class Payone_Core_Model_Payment_Method_OnlineBankTransferIdl
 
         return $this->matchingConfigs;
     }
+
+    /**
+     * @param $redirectUrl
+     */
+    public function setRedirectUrl($redirectUrl)
+    {
+        $oSession = Mage::getSingleton('checkout/session');
+        $oSession->setPayoneExternalCheckoutActive(true);
+        $this->redirectUrl = $redirectUrl;
+    }
 }

--- a/app/code/community/Payone/Core/Model/Payment/Method/OnlineBankTransferP24.php
+++ b/app/code/community/Payone/Core/Model/Payment/Method/OnlineBankTransferP24.php
@@ -63,4 +63,14 @@ class Payone_Core_Model_Payment_Method_OnlineBankTransferP24
 
         return $this->matchingConfigs;
     }
+
+    /**
+     * @param $redirectUrl
+     */
+    public function setRedirectUrl($redirectUrl)
+    {
+        $oSession = Mage::getSingleton('checkout/session');
+        $oSession->setPayoneExternalCheckoutActive(true);
+        $this->redirectUrl = $redirectUrl;
+    }
 }

--- a/app/code/community/Payone/Core/Model/Payment/Method/OnlineBankTransferPostFinanceCard.php
+++ b/app/code/community/Payone/Core/Model/Payment/Method/OnlineBankTransferPostFinanceCard.php
@@ -63,4 +63,14 @@ class Payone_Core_Model_Payment_Method_OnlineBankTransferPostFinanceCard
 
         return $this->matchingConfigs;
     }
+
+    /**
+     * @param $redirectUrl
+     */
+    public function setRedirectUrl($redirectUrl)
+    {
+        $oSession = Mage::getSingleton('checkout/session');
+        $oSession->setPayoneExternalCheckoutActive(true);
+        $this->redirectUrl = $redirectUrl;
+    }
 }

--- a/app/code/community/Payone/Core/Model/Payment/Method/OnlineBankTransferPostFinanceEfinance.php
+++ b/app/code/community/Payone/Core/Model/Payment/Method/OnlineBankTransferPostFinanceEfinance.php
@@ -63,4 +63,14 @@ class Payone_Core_Model_Payment_Method_OnlineBankTransferPostFinanceEfinance
 
         return $this->matchingConfigs;
     }
+
+    /**
+     * @param $redirectUrl
+     */
+    public function setRedirectUrl($redirectUrl)
+    {
+        $oSession = Mage::getSingleton('checkout/session');
+        $oSession->setPayoneExternalCheckoutActive(true);
+        $this->redirectUrl = $redirectUrl;
+    }
 }

--- a/app/code/community/Payone/Core/Model/Payment/Method/OnlineBankTransferSofortueberweisung.php
+++ b/app/code/community/Payone/Core/Model/Payment/Method/OnlineBankTransferSofortueberweisung.php
@@ -63,4 +63,14 @@ class Payone_Core_Model_Payment_Method_OnlineBankTransferSofortueberweisung
 
         return $this->matchingConfigs;
     }
+
+    /**
+     * @param $redirectUrl
+     */
+    public function setRedirectUrl($redirectUrl)
+    {
+        $oSession = Mage::getSingleton('checkout/session');
+        $oSession->setPayoneExternalCheckoutActive(true);
+        $this->redirectUrl = $redirectUrl;
+    }
 }

--- a/app/code/community/Payone/Core/Model/Payment/Method/Wallet.php
+++ b/app/code/community/Payone/Core/Model/Payment/Method/Wallet.php
@@ -62,19 +62,14 @@ class Payone_Core_Model_Payment_Method_Wallet extends Payone_Core_Model_Payment_
 
         return $this->matchingConfigs;
     }
-    
+
     /**
-     * @note Getter is
      * @param $redirectUrl
      */
     public function setRedirectUrl($redirectUrl)
     {
-        if(stripos($redirectUrl, 'paypal') !== false) {
-            $oSession = Mage::getSingleton('checkout/session');
-            $oSession->setPayoneIsRedirectedToPayPal(true);
-        }
-
+        $oSession = Mage::getSingleton('checkout/session');
+        $oSession->setPayoneExternalCheckoutActive(true);
         $this->redirectUrl = $redirectUrl;
     }
-    
 }

--- a/app/code/community/Payone/Core/Model/Payment/Method/WalletAliPay.php
+++ b/app/code/community/Payone/Core/Model/Payment/Method/WalletAliPay.php
@@ -75,19 +75,13 @@ class Payone_Core_Model_Payment_Method_WalletAliPay extends Payone_Core_Model_Pa
         return $this->matchingConfigs;
     }
 
-    
     /**
-     * @note Getter is
      * @param $redirectUrl
      */
     public function setRedirectUrl($redirectUrl)
     {
-        if(stripos($redirectUrl, 'paypal') !== false) {
-            $oSession = Mage::getSingleton('checkout/session');
-            $oSession->setPayoneIsRedirectedToPayPal(true);
-        }
-
+        $oSession = Mage::getSingleton('checkout/session');
+        $oSession->setPayoneExternalCheckoutActive(true);
         $this->redirectUrl = $redirectUrl;
     }
-    
 }

--- a/app/code/community/Payone/Core/Model/Payment/Method/WalletPaydirekt.php
+++ b/app/code/community/Payone/Core/Model/Payment/Method/WalletPaydirekt.php
@@ -74,19 +74,14 @@ class Payone_Core_Model_Payment_Method_WalletPaydirekt extends Payone_Core_Model
 
         return $this->matchingConfigs;
     }
-    
+
     /**
-     * @note Getter is
      * @param $redirectUrl
      */
     public function setRedirectUrl($redirectUrl)
     {
-        if(stripos($redirectUrl, 'paypal') !== false) {
-            $oSession = Mage::getSingleton('checkout/session');
-            $oSession->setPayoneIsRedirectedToPayPal(true);
-        }
-
+        $oSession = Mage::getSingleton('checkout/session');
+        $oSession->setPayoneExternalCheckoutActive(true);
         $this->redirectUrl = $redirectUrl;
     }
-    
 }

--- a/app/code/community/Payone/Core/Model/Payment/Method/WalletPaypalExpress.php
+++ b/app/code/community/Payone/Core/Model/Payment/Method/WalletPaypalExpress.php
@@ -76,17 +76,12 @@ class Payone_Core_Model_Payment_Method_WalletPaypalExpress extends Payone_Core_M
     }
     
     /**
-     * @note Getter is
      * @param $redirectUrl
      */
     public function setRedirectUrl($redirectUrl)
     {
-        if(stripos($redirectUrl, 'paypal') !== false) {
-            $oSession = Mage::getSingleton('checkout/session');
-            $oSession->setPayoneIsRedirectedToPayPal(true);
-        }
-
+        $oSession = Mage::getSingleton('checkout/session');
+        $oSession->setPayoneExternalCheckoutActive(true);
         $this->redirectUrl = $redirectUrl;
     }
-    
 }

--- a/app/code/community/Payone/Core/controllers/Checkout/CartController.php
+++ b/app/code/community/Payone/Core/controllers/Checkout/CartController.php
@@ -111,36 +111,6 @@ class Payone_Core_Checkout_CartController extends Mage_Checkout_CartController
      */
     public function indexAction()
     {
-        /** @var Mage_Checkout_Model_Session $oSession */
-        $oSession = Mage::getSingleton('checkout/session');
-        
-        if ($oSession->getPayoneIsRedirectedToPayPal() === true) {
-            $oSession->unsPayoneIsRedirectedToPayPal();
-            
-            // Load order
-            $oOrder = $this->getOrderByCheckoutSession($oSession);
-            if ($oOrder) {
-                // Cancel order and add history comment:
-                if ($oOrder->canCancel()) {
-                    $oOrder->cancel();
-                    $sMessage = $this->helper()->__('The Payone transaction has been canceled.');
-                    $oOrder->addStatusHistoryComment($sMessage, Mage_Sales_Model_Order::STATE_CANCELED);
-                    $oOrder->save();
-                    // Add a notice to Magento checkout and
-                    // prevent jumping forward in history:
-                    $sNotice = $this->helper()->__('The order has been canceled.');
-                    $oSession->setData('has_canceled_order_text', $sNotice);
-                    $oSession->setData('has_canceled_order', true);
-                    $oSession->addNotice($sNotice);
-                }
-                // Load quote
-                $oQuote = $this->getQuoteByCheckoutSession($oSession);
-                if ($oQuote) {
-                    $this->reactivateQuote($oQuote);
-                }
-            }
-        }
-
         return parent::indexAction();
     }
 }

--- a/app/code/community/Payone/Core/controllers/Checkout/Onepage/PaymentController.php
+++ b/app/code/community/Payone/Core/controllers/Checkout/Onepage/PaymentController.php
@@ -41,42 +41,35 @@ class Payone_Core_Checkout_Onepage_PaymentController extends Payone_Core_Control
     {
         try {
             $oSession = Mage::getSingleton('checkout/session');
-            $oSession->unsPayoneIsRedirectedToPayPal();
-            
+            $oSession->unsPayoneExternalCheckoutActive();
             $this->checkoutCancel(true);
         } catch (Exception $e) {
             $this->handleException($e);
         }
-
-        // Redirect customer to cart
-        $this->_redirect('checkout/cart');
+        $this->forwardToCart();
     }
 
     /**
-     * @return mixed
+     * Payment was successful and order will be saved.
      */
     public function successAction()
     {
         try {
             $oSession = Mage::getSingleton('checkout/session');
-            $oSession->unsPayoneIsRedirectedToPayPal();
-            
+            $oSession->unsPayoneExternalCheckoutActive();
             $success = $this->checkoutSucccess();
-
             if ($success === true) {
                 // Payment is okay. Redirect to standard Magento success page:
-                $this->_redirect(
-                    'checkout/onepage/success', array(
-                    '_nosid' => true,
-                    '_secure' => Mage::app()->getStore()->isCurrentlySecure())
-                );
+                $this->_redirect('checkout/onepage/success', [
+                    '_nosid'  => true,
+                    '_secure' => Mage::app()->getStore()->isCurrentlySecure(),
+                ]);
                 return;
             }
         } catch (Exception $e) {
             $this->handleException($e);
         }
-
-        $this->_redirect('checkout/cart');
+        $this->forwardToCart();
     }
 
     /**
@@ -87,15 +80,22 @@ class Payone_Core_Checkout_Onepage_PaymentController extends Payone_Core_Control
     {
         try {
             $oSession = Mage::getSingleton('checkout/session');
-            $oSession->unsPayoneIsRedirectedToPayPal();
-            
+            $oSession->unsPayoneExternalCheckoutActive();
             $this->checkoutCancel(true);
         } catch (Exception $e) {
             $this->handleException($e);
         }
+        $this->forwardToCart();
+    }
 
-        // Redirect customer to cart
-        $this->_redirect('checkout/cart');
+    protected function forwardToCart()
+    {
+        $this->getRequest()
+            ->setInternallyForwarded()
+            ->setRouteName('checkout')
+            ->setControllerName('cart')
+            ->setActionName('index')
+            ->setDispatched(false);
     }
 
     /**

--- a/app/code/community/Payone/Core/etc/config.xml
+++ b/app/code/community/Payone/Core/etc/config.xml
@@ -325,6 +325,15 @@
         </template>
 
         <events>
+            <controller_action_predispatch>
+                <observers>
+                    <payone_core_observer>
+                        <type>singleton</type>
+                        <class>payone_core/observer_checkout_onepage_payment_external</class>
+                        <method>maintainCheckoutSession</method>
+                    </payone_core_observer>
+                </observers>
+            </controller_action_predispatch>
             <sales_quote_address_validate_after>
                 <observers>
                     <payone_core_observer>


### PR DESCRIPTION
* Navigation in checkout sessions using an online bank transfer provider will be handled just the same as sessions using a wallet payment provider.
* Any parallel user activity in the shop (e.g. in a second tab/window) during external payment handling results in order cancellation and cart restoration now.