### PR TITLE
Fixed PHP notices

### DIFF
--- a/app/code/community/Payone/Core/Model/Observer/Checkout/Onepage/MultiplePaymentCheck.php
+++ b/app/code/community/Payone/Core/Model/Observer/Checkout/Onepage/MultiplePaymentCheck.php
@@ -59,6 +59,11 @@ class Payone_Core_Model_Observer_Checkout_Onepage_MultiplePaymentCheck extends P
         /** @var Mage_Checkout_OnepageController|Payone_Core_Checkout_OnepageController $controllerAction */
         $controllerAction = $observer->getEvent()->getControllerAction();
         $paymentData = $controllerAction->getRequest()->getPost('payment', []);
+
+        if (!array_key_exists('method', $paymentData)) {
+            return;
+        }
+
         $selectedPaymentMethod = $paymentData['method'];
 
         if (!array_key_exists($selectedPaymentMethod, $this->paymentMethodChecks) ||


### PR DESCRIPTION
We're getting PHP notices, because sometimes key "method" does not exist in $paymentData.