### PR TITLE
Assign order to logged in customer instead of creating a guest order

### DIFF
--- a/app/code/community/Payone/Core/Model/Service/Amazon/Pay/Checkout.php
+++ b/app/code/community/Payone/Core/Model/Service/Amazon/Pay/Checkout.php
@@ -268,10 +268,22 @@ class Payone_Core_Model_Service_Amazon_Pay_Checkout
         $this->quote->getShippingAddress()
             ->setData('should_ignore_validation', true);
         $this->quote->collectTotals()->save();
-        $this->quote->setCustomerId(null)
-            ->setCustomerEmail($this->quote->getBillingAddress()->getEmail())
-            ->setCustomerIsGuest(true)
-            ->setCustomerGroupId(\Mage_Customer_Model_Group::NOT_LOGGED_IN_ID);
+        if (Mage::getSingleton('customer/session')->isLoggedIn()) {
+            $customer = Mage::getSingleton('customer/session')->getCustomer();
+            $customerId = $customer->getId();
+            $customerEmail = $customer->getEmail();
+            $customerGroupId = Mage::getSingleton('customer/session')->getCustomerGroupId();
+            $this->quote->setCustomerId($customerId)
+                ->setCustomerEmail($customerEmail)
+                ->setCustomerIsGuest(false)
+                ->setCustomerGroupId($customerGroupId);
+        }
+        else {
+            $this->quote->setCustomerId(null)
+                ->setCustomerEmail($this->quote->getBillingAddress()->getEmail())
+                ->setCustomerIsGuest(true)
+                ->setCustomerGroupId(\Mage_Customer_Model_Group::NOT_LOGGED_IN_ID);
+        }
         /** @var \Payone_Core_Model_Session $session */
         $session = Mage::getSingleton('payone_core/session');
         $session->setData('amazon_add_paydata', [

--- a/app/design/frontend/base/default/template/payone/core/amazon/pay/shortcut.phtml
+++ b/app/design/frontend/base/default/template/payone/core/amazon/pay/shortcut.phtml
@@ -85,7 +85,9 @@ if (!empty($config)) :
 <?php if ($this::$counter <= 1) : ?>
     <!-- Load script Widgets.js from Amazon -->
     <!-- URL changes to https://static-eu.payments-amazon.com/OffAmazonPayments/eur/lpa/js/Widgets.js when mode=live -->
-    <script async="async" src='https://static-eu.payments-amazon.com/OffAmazonPayments/eur/sandbox/lpa/js/Widgets.js'
+    <?php $useSandbox = $config->getMode() === \Payone_Enum_Mode::TEST ? '/sandbox' : '' ?>
+    <script async="async"
+            src='<?php echo "https://static-eu.payments-amazon.com/OffAmazonPayments/eur$useSandbox/lpa/js/Widgets.js" ?>'
     ></script>
 <?php endif; ?>
 <?php endif; ?>


### PR DESCRIPTION
If a customer is logged in during checkout and completes the order with Amazon Pay, the order is not assigned to the existing customer and instead a guest order created. With this fix the order is assigned to the customer if he is logged in during Amazon Pay checkout.