### PR TITLE
Assign order to logged in customer instead of creating guest order

### DIFF
--- a/app/code/community/Payone/Core/Model/Service/Amazon/Pay/Checkout.php
+++ b/app/code/community/Payone/Core/Model/Service/Amazon/Pay/Checkout.php
@@ -280,6 +280,8 @@ class Payone_Core_Model_Service_Amazon_Pay_Checkout
         }
         else {
             $this->quote->setCustomerId(null)
+                ->setCustomerFirstname($this->quote->getBillingAddress()->getFirstname())
+                ->setCustomerLastname($this->quote->getBillingAddress()->getLastname())
                 ->setCustomerEmail($this->quote->getBillingAddress()->getEmail())
                 ->setCustomerIsGuest(true)
                 ->setCustomerGroupId(\Mage_Customer_Model_Group::NOT_LOGGED_IN_ID);

--- a/app/code/community/Payone/Core/Model/Service/Amazon/Pay/Checkout.php
+++ b/app/code/community/Payone/Core/Model/Service/Amazon/Pay/Checkout.php
@@ -268,10 +268,22 @@ class Payone_Core_Model_Service_Amazon_Pay_Checkout
         $this->quote->getShippingAddress()
             ->setData('should_ignore_validation', true);
         $this->quote->collectTotals()->save();
-        $this->quote->setCustomerId(null)
-            ->setCustomerEmail($this->quote->getBillingAddress()->getEmail())
-            ->setCustomerIsGuest(true)
-            ->setCustomerGroupId(\Mage_Customer_Model_Group::NOT_LOGGED_IN_ID);
+        if (Mage::getSingleton('customer/session')->isLoggedIn()) {
+            $customer = Mage::getSingleton('customer/session')->getCustomer();
+            $customerId = $customer->getId();
+            $customerEmail = $customer->getEmail();
+            $customerGroupId = Mage::getSingleton('customer/session')->getCustomerGroupId();
+            $this->quote->setCustomerId($customerId)
+                ->setCustomerEmail($customerEmail)
+                ->setCustomerIsGuest(false)
+                ->setCustomerGroupId($customerGroupId);
+        }
+        else {
+            $this->quote->setCustomerId(null)
+                ->setCustomerEmail($this->quote->getBillingAddress()->getEmail())
+                ->setCustomerIsGuest(true)
+                ->setCustomerGroupId(\Mage_Customer_Model_Group::NOT_LOGGED_IN_ID);
+        }
         /** @var \Payone_Core_Model_Session $session */
         $session = Mage::getSingleton('payone_core/session');
         $session->setData('amazon_add_paydata', [


### PR DESCRIPTION
If a customer is logged in and uses Amazon Pay, the order is not assigned to him and instead a guest order is hardcoded to be created. 

This fixes it and assigns the order to the logged in customer instead of creating a guest order.