### PR TITLE
Hide Amazon Pay Button in Facebook Inapp Browser because the browser is not supported by Amazon

### DIFF
--- a/app/design/frontend/base/default/template/payone/core/amazon/pay/shortcut.phtml
+++ b/app/design/frontend/base/default/template/payone/core/amazon/pay/shortcut.phtml
@@ -39,6 +39,7 @@ if (!empty($config)) :
     /** @var int $buttonIdentifier */
     $buttonIdentifier = "LoginWithAmazon" . (++$this::$counter);
 ?>
+<?php if(strpos($_SERVER['HTTP_USER_AGENT'], 'FBAN/') === false && strpos($_SERVER['HTTP_X_REQUESTED_WITH'], 'com.facebook.') === false): ?>
 <div class="amazon-checkout-button">
     <?php if ($this->getData('show_or_position') === 'before') : ?>
         <?php echo $buttonDelimiter; ?>
@@ -87,5 +88,6 @@ if (!empty($config)) :
     <!-- URL changes to https://static-eu.payments-amazon.com/OffAmazonPayments/eur/lpa/js/Widgets.js when mode=live -->
     <script async="async" src='https://static-eu.payments-amazon.com/OffAmazonPayments/eur/sandbox/lpa/js/Widgets.js'
     ></script>
+<?php endif; ?>
 <?php endif; ?>
 <?php endif; ?>


### PR DESCRIPTION
Uses iOS FB-Inapp Browser:
strpos($_SERVER['HTTP_USER_AGENT'], 'FBAN/') === true

Uses Android FB-Inapp Browser:
strpos($_SERVER['HTTP_X_REQUESTED_WITH'], 'com.facebook.') === true