### PR TITLE
MAGE-344: Re-enable Paydirekt reference number patch

### DIFF
--- a/app/code/community/Payone/Core/Model/Mapper/ApiRequest/Payment/Authorize/Abstract.php
+++ b/app/code/community/Payone/Core/Model/Mapper/ApiRequest/Payment/Authorize/Abstract.php
@@ -856,13 +856,11 @@ abstract class Payone_Core_Model_Mapper_ApiRequest_Payment_Authorize_Abstract
         if($aPostPayment && array_key_exists('payone_wallet_type', $aPostPayment)) {
             $sType = $aPostPayment['payone_wallet_type'];
         } else {
-            $sType = Payone_Api_Enum_WalletType::PAYPAL_EXPRESS;
-        }
-
-        if($aPostPayment && array_key_exists('payone_wallet_paydirekt_type', $aPostPayment)) {
-            $sType = $aPostPayment['payone_wallet_paydirekt_type'];
-        } else {
-            $sType = Payone_Api_Enum_WalletType::PAYPAL_EXPRESS;
+            if($aPostPayment && array_key_exists('payone_wallet_paydirekt_type', $aPostPayment)) {
+                $sType = $aPostPayment['payone_wallet_paydirekt_type'];
+            } else {
+                $sType = Payone_Api_Enum_WalletType::PAYPAL_EXPRESS;
+            }
         }
 
         return $sType;


### PR DESCRIPTION
Fix the walletType recognition to re-enable Paydirekt reference number patch