### PR TITLE
Missing Store ID on TransactionStatus Execute

### DIFF
--- a/app/code/community/Payone/Core/Model/Service/TransactionStatus/Execute.php
+++ b/app/code/community/Payone/Core/Model/Service/TransactionStatus/Execute.php
@@ -78,6 +78,18 @@ class Payone_Core_Model_Service_TransactionStatus_Execute extends Payone_Core_Mo
     {
         $storeId = $transactionStatus->getStoreId();
 
+        /**
+         * Check if the Store ID exists, if not fetch the order from the reference
+         */
+        if (is_null($storeId)) {
+            $order = $this->getFactory()->getModelSalesOrder();
+            $order->loadByIncrementId($transactionStatus->getReference());
+
+            if ($order && $order->getId()) {
+                $storeId = $order->getStoreId();
+            }
+        }
+
         $this->helper()->logCronjobMessage("ID: {$transactionStatus->getId()} - Execute - Execute TransactionStatus action: {$transactionStatus->getTxaction()} - store-id: {$storeId}", $storeId);
 
         $storeBefore = $this->getApp()->getStore();


### PR DESCRIPTION
PayOne sends the Transactionstatus Update to the Shop.
But the Table fields "store_id" and "order_id" are "NULL" by default.

While PayOne tries to process the Transaction Status it sets the Store to the Store ID from the Order.
The Problem is that the Store ID does not exists and the Cronjob is running in the Admin Store (ID: 0).

So many Configurations like Sender Mail and others are not fetched correctly. 
They are fetched from the Admin Store instead of the Store to which the Order belongs.
This Update fixes the Problem and fetches the Store ID from the Order by Reference of the IncrementID.

During the Process the Fields "store_id" and "order_id" will be saved to the Table Entry.
But at this point it is to late. The correct Store ID is needed where the Store "emulation" starts not during the Process.