### PR TITLE
MAGE-348: Raise flag when order is cancelled from external payment

### DIFF
--- a/app/code/community/Payone/Core/Model/Observer/Checkout/Onepage.php
+++ b/app/code/community/Payone/Core/Model/Observer/Checkout/Onepage.php
@@ -107,6 +107,14 @@ class Payone_Core_Model_Observer_Checkout_Onepage extends Payone_Core_Model_Obse
 
     }
 
+    public function removeOrderCancellationFlag(Varien_Event_Observer $observer)
+    {
+        $checkoutSession = $this->getFactory()->getSingletonCheckoutSession();
+        $checkoutSession->setData('order_got_canceled', false);
+
+        return true;
+    }
+
     /**
      * @return bool
      */

--- a/app/code/community/Payone/Core/Model/Observer/Checkout/Onepage/Payment/External.php
+++ b/app/code/community/Payone/Core/Model/Observer/Checkout/Onepage/Payment/External.php
@@ -76,7 +76,8 @@ class Payone_Core_Model_Observer_Checkout_Onepage_Payment_External extends Payon
                     $quoteId = $oSession->getLastQuoteId();
                     $oQuote = $this->getFactory()->getModelSalesQuote();
                     $oQuote->load($quoteId);
-                    if ($oQuote && $oQuote->getId()) {
+                    $blCancellationFlag = $oSession->getData('order_got_canceled');
+                    if ($oQuote && $oQuote->getId() && $blCancellationFlag !== true) {
                         $oQuote->setIsActive(1)
                             ->setReservedOrderId(null)
                             ->save();

--- a/app/code/community/Payone/Core/etc/config.xml
+++ b/app/code/community/Payone/Core/etc/config.xml
@@ -576,6 +576,15 @@
                     </payone_service_quote_submit_failure>
                 </observers>
             </sales_model_service_quote_submit_failure>
+            <checkout_onepage_controller_success_action>
+                <observers>
+                    <payone_core_observer>
+                        <type>singleton</type>
+                        <class>payone_core/observer_checkout_onepage</class>
+                        <method>removeOrderCancellationFlag</method>
+                    </payone_core_observer>
+                </observers>
+            </checkout_onepage_controller_success_action>
         </events>
     </global>
 


### PR DESCRIPTION
- Place a new order when successAction is triggered and cancel flag is up