### PR TITLE
Update External.php

### DIFF
--- a/app/code/community/Payone/Core/Model/Observer/Checkout/Onepage/Payment/External.php
+++ b/app/code/community/Payone/Core/Model/Observer/Checkout/Onepage/Payment/External.php
@@ -55,7 +55,7 @@ class Payone_Core_Model_Observer_Checkout_Onepage_Payment_External extends Payon
                 $orderId = $oSession->getLastOrderId();
                 $oOrder = $this->getFactory()->getModelSalesOrder();
                 $oOrder->load($orderId);
-                if ($oOrder && empty($oSession->getData('order_got_canceled'))) {
+                if ($oOrder && empty($oSession->getData('order_got_canceled')) == false) {
                     // Cancel order and add history comment:
                     if ($oOrder->canCancel()) {
                         $oOrder->cancel();


### PR DESCRIPTION
From my point of view the boolean check is the wrong, because if the flag is set, it means, that the order is canceled

in https://github.com/PAYONE-GmbH/magento-1/compare/v4.1.6...master the other check are now completely removed, which I don't really understand