### PR TITLE
remove double-if

### DIFF
--- a/app/design/frontend/base/default/template/payone/core/mastercard/masterpass/shortcut.phtml
+++ b/app/design/frontend/base/default/template/payone/core/mastercard/masterpass/shortcut.phtml
@@ -29,7 +29,6 @@
 <button class="masterpassCheckout" onclick="initCheckout()">
     <img src="https://masterpass.com/dyn/img/btn/global/mp_chk_btn_147x034px.svg"/>
 </button>
-<?php if ($this->isMasterpassActive()) : ?>
 
     <?php if ($this->isOrPositionBefore()): ?>
         <span class="paypal-or"><?php echo $this->__('-OR-');?></span>


### PR DESCRIPTION
Fixes:

Parse error: syntax error, unexpected end of file, expecting elseif (T_ELSEIF) or else (T_ELSE) or endif (T_ENDIF) in app/design/frontend/base/default/template/payone/core/mastercard/masterpass/shortcut.phtml on line 76