### PR TITLE
MAGE-382: updates around credit card recognition

### DIFF
--- a/app/code/community/Payone/Core/Block/Payment/Method/Form/Creditcard.php
+++ b/app/code/community/Payone/Core/Block/Payment/Method/Form/Creditcard.php
@@ -497,4 +497,17 @@ class Payone_Core_Block_Payment_Method_Form_Creditcard
 
         return $ccTypes;
     }
+
+    /**
+     * @return bool
+     */
+    public function getHideCreditCardSelectorConfig()
+    {
+        $hideCcTypeSelector =  $this->getConfigGeneral()->getPaymentCreditcard()->getCcTypeHideSelector();
+        if(!empty($hideCcTypeSelector)){
+            return (bool) $hideCcTypeSelector;
+        }
+
+        return false;
+    }
 }

--- a/app/code/community/Payone/Core/Model/Config/General/PaymentCreditcard.php
+++ b/app/code/community/Payone/Core/Model/Config/General/PaymentCreditcard.php
@@ -40,6 +40,7 @@ class Payone_Core_Model_Config_General_PaymentCreditcard extends Payone_Core_Mod
     protected $sCCTemplate = '';
     protected $sCCRequestType = 'AJAX';
     protected $iCCTypeAutoRecognition = 0;
+    protected $ccTypeHideSelector = 0;
 
     /**
      * @param int $min_validity_period
@@ -86,5 +87,14 @@ class Payone_Core_Model_Config_General_PaymentCreditcard extends Payone_Core_Mod
     {
         return $this->iCCTypeAutoRecognition;
     }
-    
+
+    public function setCcTypeHideSelector($iCcTypeHideSelector)
+    {
+        $this->ccTypeHideSelector = $iCcTypeHideSelector;
+    }
+
+    public function getCcTypeHideSelector()
+    {
+        return $this->ccTypeHideSelector;
+    }
 }

--- a/app/code/community/Payone/Core/etc/system.xml
+++ b/app/code/community/Payone/Core/etc/system.xml
@@ -557,11 +557,21 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </cc_type_auto_recognition>
+                        <cc_type_hide_selector>
+                            <label>Request-type</label>
+                            <label>Hide the credit card type selector</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>40</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </cc_type_hide_selector>
                         <cc_template translate="label">
                             <label>Input-configuration</label>
                             <frontend_model>payone_core/adminhtml_system_config_form_field_creditcardTemplate</frontend_model>
                             <backend_model>adminhtml/system_config_backend_serialized_array</backend_model>
-                            <sort_order>30</sort_order>
+                            <sort_order>50</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>

--- a/app/design/adminhtml/default/default/template/payone/core/system/config/tooltip/general/payment_creditcard.phtml
+++ b/app/design/adminhtml/default/default/template/payone/core/system/config/tooltip/general/payment_creditcard.phtml
@@ -33,4 +33,9 @@
     <br>
     <?php echo $this->__('When Enabled, the credit card type is recognized through card number. If Disabled, the type selector is always displayed.'); ?><br>
 </div>
+<div class="field-name"><?php echo $this->__('Hide the credit card type selector'); ?></div>
+<div class="field-description">
+    <br>
+    <?php echo $this->__('When Enabled, the credit card type selector is hidden. If Disabled, the type selector is displayed.'); ?><br>
+</div>
 <br>

--- a/app/design/frontend/base/default/template/payone/core/payment/method/form/creditcard.phtml
+++ b/app/design/frontend/base/default/template/payone/core/payment/method/form/creditcard.phtml
@@ -24,7 +24,7 @@
 /** @var $this Payone_Core_Block_Payment_Method_Form_Creditcard */
 
  $hideCvcTypes = $this->getHideCvcTypes();
-
+$hideCcTypeSelector = $this->getHideCreditCardSelectorConfig();
 
 
 $code = $this->getMethodCode();
@@ -159,10 +159,20 @@ $iCheckValidation = (int)$this->showCvcInput();
     <?php } else { ?>
         <ul id="payment_form_<?php echo $code ?>" style="display:none">
             <li>
+                <div style="display:none" id="payone_creditcard_hosted_error" class="validation-advice">
+                    <?php echo $this->__('Please fill in all required fields'); ?>.
+                </div>
+            </li>
+            <li>
                 <div class="input-box">
-                    <div style="display:none" id="payone_creditcard_hosted_error" class="validation-advice">
-                        <?php echo $this->__('Please fill in all required fields'); ?>.
-                    </div>
+                    <label for="cardpanInput"><?php echo $this->__('Credit Card Number'); ?>&nbsp;<span class="required">*</span></label>
+                    <br class="clear"/>
+                    <span class="inputIframe" id="cardpan"></span>
+                    <span id="<?php echo $code ?>_cc_type_logo"><img style="display: inline; padding-bottom: 4px" src="" /></span>
+                </div>
+            </li>
+            <li <?php if($hideCcTypeSelector): ?>style="display: none" <?php endif; ?>
+                <div class="input-box">
                     <label for="<?php echo $code; ?>_cc_type"><?php echo $this->__('Credit Card Type'); ?>
                         <span class="required">*</span>
                     </label><br class="clear"/>
@@ -177,15 +187,7 @@ $iCheckValidation = (int)$this->showCvcInput();
                             </option>
                         <?php endforeach; ?>
                     </select>
-                    <span id="<?php echo $code ?>_cc_type_logo"><img style="display: inline; vertical-align: bottom" src="" /></span>
                     <input type="hidden" id="<?php echo $code ?>_cc_type" name="payment[cc_type]" value="<?php echo $this->getCreditCardType();?>" class=""/>
-                </div>
-            </li>
-            <li>
-                <div class="input-box">
-                    <label for="cardpanInput"><?php echo $this->__('Credit Card Number'); ?>&nbsp;<span class="required">*</span></label>
-                    <br class="clear"/>
-                    <span class="inputIframe" id="cardpan"></span>
                 </div>
             </li>
             <li>

--- a/app/locale/de_DE/Payone_Core.csv
+++ b/app/locale/de_DE/Payone_Core.csv
@@ -1213,6 +1213,8 @@ The <a target='_blank' href='https://www.ratepay.com/zgb-dse'>additional terms a
 "Your session has expired. Please sign in again by clicking on the Amazon Pay Button.","Ihre Sitzung ist abgelaufen. Bitte loggen Sie sich erneut ein, indem Sie auf den Amazon Pay Button klicken."
 "Enable Credit Card type auto recognition","Kreditkartennummer automatische Erkennung aktivieren"
 "When Enabled, the credit card type is recognized through card number. If Disabled, the type selector is always displayed.","<Übersetzen>"
+"Hide the credit card type selector","Kreditkarten-Typ-Selektor ausblenden"
+"When Enabled, the credit card type selector is hidden. If Disabled, the type selector is displayed.","Wenn diese Option aktiviert ist, ist die Kreditkartenauswahl ausgeblendet. Wenn deaktiviert, wird die Typenauswahl angezeigt."
 
 "Ratepay Direct Debit","Ratepay Lastschrift"
 "Creditors ID: ","Gläubiger-ID: "


### PR DESCRIPTION
- Switch fields to present cc number before cc type selection
- implement config option to completely hide the cc type selector