### PR TITLE
removed unnecessary newline

### DIFF
--- a/app/design/frontend/base/default/template/payone/core/mastercard/masterpass/shortcut.phtml
+++ b/app/design/frontend/base/default/template/payone/core/mastercard/masterpass/shortcut.phtml
@@ -21,7 +21,6 @@
  * @link            http://www.fatchip.de
  */
 ?>
-
 <?php
 /** @var Payone_Core_Block_Mastercard_Masterpass_Shortcut $this  */
 ?>


### PR DESCRIPTION
This new line is output no matter if MasterPas is enabled or not. Hence, the condition `$methodHtml = $this->getMethodHtml($method)` in `checkout/cart.phtml` is passed, which leads to an empty `<li>` element when MasterPass is disabled.