### PR TITLE
fixed potential bug during payment method restore

### DIFF
--- a/app/code/community/Payone/Core/Model/Observer/Checkout/Onepage/Payment/Methods.php
+++ b/app/code/community/Payone/Core/Model/Observer/Checkout/Onepage/Payment/Methods.php
@@ -189,8 +189,10 @@ class Payone_Core_Model_Observer_Checkout_Onepage_Payment_Methods
             $payoneCustomer = Mage::getModel('payone_core/domain_customer');
             $payoneCustomer = $payoneCustomer->loadByCustomerIdPaymentCode($customer->getId(), $method);
             $data = $payoneCustomer->getCustomerData();
-            foreach ($data as $key => $value) {
-                $quote->getPayment()->setData($key, $value);
+            if (null !== $data) {
+                foreach ($data as $key => $value) {
+                    $quote->getPayment()->setData($key, $value);
+                }
             }
 
             $quote->getPayment()->getMethodInstance();


### PR DESCRIPTION
`getCustomerData` may return `null` (e.g. for `payone_advance_payment`), which leads to an "Invalid argument supplied for foreach()" error, so that the last payment method is not set correctly.