### PR TITLE
scroll to error message on CC hosted error

### DIFF
--- a/js/payone/core/creditcard.js
+++ b/js/payone/core/creditcard.js
@@ -205,6 +205,7 @@ PAYONE.Service.CreditCardCheck = function (handler, form, config) {
             this.iframes.creditCardCheck('processPayoneResponseCCHosted');
         } else {
             $('payone_creditcard_hosted_error').show();
+            $('payone_creditcard_hosted_error').scrollTo();
         }
     }
 


### PR DESCRIPTION
On mobile devices, the CC data form may not be visible if the user clicks the "Continue" button. If there is a CC hosted error, the user cannot continue and maybe the shown error is not in the viewport. Hence, it is a good idea to scroll to the error messag as implemented in this PR.