### PR TITLE
prevent success action for non-paid orders

### DIFF
--- a/app/code/community/Payone/Core/controllers/Checkout/OnepageController.php
+++ b/app/code/community/Payone/Core/controllers/Checkout/OnepageController.php
@@ -365,4 +365,22 @@ class Payone_Core_Checkout_OnepageController extends Mage_Checkout_OnepageContro
         $this->startCancellationHandler();
         return parent::indexAction();
     }
+
+    /**
+     * Prevents success action for non-paid orders
+     * @return void
+     */
+    public function successAction()
+    {
+        /** @var Mage_Checkout_Model_Session $oSession */
+        $oSession = Mage::getSingleton('checkout/session');
+
+        // this should be unset by Payone_Core_Checkout_Onepage_PaymentController
+        if ($oSession->getPayoneExternalCheckoutActive() === true) {
+            $this->_redirect('checkout/cart');
+            return;
+        }
+
+        parent::successAction();
+    }
 }


### PR DESCRIPTION
Dieser PR verhindert, dass bei noch nicht bezahlten Bestellungen die Success Action des OnepageControllers aufgerufen werden kann.

Es gibt zwar noch die zusätzlichen Informationen zur Bezahlung, die in den Kommentaren der Bestellung stehen, aber insbesondere bei Shops die auf Events (wie z.B. checkout_onepage_controller_success_action) lauschen ist das sehr kritisch.
Meiner Meinung nach sollten nicht bezahlte Bestellungen nicht in der Lage sein erfolgreich abzuschließen.

Reproduzierung:
* PayPal Bestellung triggern und weiterleiten lassen
* /checkout/onepage/success aufrufen