### PR TITLE
introduce cache bypass to fix issues with invalid store configs

### DIFF
--- a/app/code/community/Payone/Core/Helper/Config.php
+++ b/app/code/community/Payone/Core/Helper/Config.php
@@ -37,11 +37,13 @@ class Payone_Core_Helper_Config
 
     /**
      * @param int $storeId
+     * @param bool $useCache
+     *
      * @return bool|Payone_Core_Model_Config_Interface
      */
-    public function getConfigStore($storeId = null)
+    public function getConfigStore($storeId = null, $useCache = true)
     {
-        $config = $this->getFactory()->getServiceInitializeConfig()->execute($storeId);
+        $config = $this->getFactory()->getServiceInitializeConfig()->execute($storeId, $useCache);
         return $config;
     }
 

--- a/app/code/community/Payone/Core/Model/Service/InitializeConfig.php
+++ b/app/code/community/Payone/Core/Model/Service/InitializeConfig.php
@@ -53,6 +53,8 @@ class Payone_Core_Model_Service_InitializeConfig
      * The Config Object will be cached
      *
      * @param int $storeId
+     * @param bool $useCache
+     *
      * @return Payone_Core_Model_Config_Interface
      */
     public function execute($storeId = null, $useCache = true)
@@ -64,12 +66,12 @@ class Payone_Core_Model_Service_InitializeConfig
             $registryKey = $this->getConfigRegistryKey($storeId);
 
             $config = $helperRegistry->registry($registryKey);
-            if ($config instanceof Payone_Core_Model_Config_Interface) {
+            if (($config instanceof Payone_Core_Model_Config_Interface) && $config->getStoreId() === $storeId) {
                 return $config;
             }
 
             $config = $this->loadFromCache();
-            if ($config instanceof Payone_Core_Model_Config_Interface) {
+            if (($config instanceof Payone_Core_Model_Config_Interface) && $config->getStoreId() === $storeId) {
                 $helperRegistry->register($registryKey, $config);
                 return $config;
             }

--- a/app/code/community/Payone/Core/Model/Service/InitializeConfig.php
+++ b/app/code/community/Payone/Core/Model/Service/InitializeConfig.php
@@ -61,10 +61,10 @@ class Payone_Core_Model_Service_InitializeConfig
     {
         $this->setStoreId($storeId);
 
-        if($useCache === true) {
-            $helperRegistry = $this->helperRegistry();
-            $registryKey = $this->getConfigRegistryKey($storeId);
+        $helperRegistry = $this->helperRegistry();
+        $registryKey = $this->getConfigRegistryKey($storeId);
 
+        if($useCache === true) {
             $config = $helperRegistry->registry($registryKey);
             if (($config instanceof Payone_Core_Model_Config_Interface) && $config->getStoreId() === $storeId) {
                 return $config;
@@ -102,6 +102,8 @@ class Payone_Core_Model_Service_InitializeConfig
         // Caching
         if ($useCache === true) {
             $this->saveToCache($config);
+            $helperRegistry->unregister($registryKey);
+            $helperRegistry->register($registryKey, $config);
         }
 
         return $config;

--- a/app/code/community/Payone/Core/Model/Service/InitializeConfig.php
+++ b/app/code/community/Payone/Core/Model/Service/InitializeConfig.php
@@ -55,21 +55,24 @@ class Payone_Core_Model_Service_InitializeConfig
      * @param int $storeId
      * @return Payone_Core_Model_Config_Interface
      */
-    public function execute($storeId = null)
+    public function execute($storeId = null, $useCache = true)
     {
         $this->setStoreId($storeId);
 
         $helperRegistry = $this->helperRegistry();
         $registryKey = $this->getConfigRegistryKey($storeId);
-        $config = $helperRegistry->registry($registryKey);
-        if ($config instanceof Payone_Core_Model_Config_Interface) {
-            return $config;
-        }
 
-        $config = $this->loadFromCache();
-        if ($config instanceof Payone_Core_Model_Config_Interface) {
-            $helperRegistry->register($registryKey, $config);
-            return $config;
+        if($useCache === true) {
+            $config = $helperRegistry->registry($registryKey);
+            if ($config instanceof Payone_Core_Model_Config_Interface) {
+                return $config;
+            }
+
+            $config = $this->loadFromCache();
+            if ($config instanceof Payone_Core_Model_Config_Interface) {
+                $helperRegistry->register($registryKey, $config);
+                return $config;
+            }
         }
 
         /** @var $config Payone_Core_Model_Config */
@@ -95,7 +98,9 @@ class Payone_Core_Model_Service_InitializeConfig
         $config->setMisc($misc);
 
         // Caching
-        $this->saveToCache($config);
+        if ($useCache === true) {
+            $this->saveToCache($config);
+        }
 
         return $config;
     }

--- a/app/code/community/Payone/Core/Model/Service/InitializeConfig.php
+++ b/app/code/community/Payone/Core/Model/Service/InitializeConfig.php
@@ -59,10 +59,10 @@ class Payone_Core_Model_Service_InitializeConfig
     {
         $this->setStoreId($storeId);
 
-        $helperRegistry = $this->helperRegistry();
-        $registryKey = $this->getConfigRegistryKey($storeId);
-
         if($useCache === true) {
+            $helperRegistry = $this->helperRegistry();
+            $registryKey = $this->getConfigRegistryKey($storeId);
+
             $config = $helperRegistry->registry($registryKey);
             if ($config instanceof Payone_Core_Model_Config_Interface) {
                 return $config;

--- a/app/code/community/Payone/Core/Model/Service/TransactionStatus/Process.php
+++ b/app/code/community/Payone/Core/Model/Service/TransactionStatus/Process.php
@@ -85,6 +85,13 @@ class Payone_Core_Model_Service_TransactionStatus_Process extends Payone_Core_Mo
         }
         $config = $this->helperConfig()->getConfigStore($order->getStoreId());
 
+        // if store-ids differ, reload config bypassing the cache
+        $this->helper()->logCronjobMessage("ID: {$transactionStatus->getId()} - Process - Config loaded with config.store-id={$config->getStoreId()}, order.store-id: {$order->getStoreId()}", $order->getStoreId());
+        if ($config->getStoreId() != $order->getStoreId()) {
+            $config = $this->helperConfig()->getConfigStore($order->getStoreId(), false);
+            // @todo we should stop processing here, this will only produce errors when working with the wrong config
+        }
+
         $this->helper()->logCronjobMessage("ID: {$transactionStatus->getId()} - Process - Update TransactionStatus", $order->getStoreId());
         $transactionStatus->setStoreId($order->getStoreId());
         $transactionStatus->setOrderId($order->getId());


### PR DESCRIPTION
This pull-request fixes issues with the Service TransactionStatus Process which run using a Cronjob.

From time to time it can happen, that you get an error message much like this one.
"Payment method configuration with id "18" not found."

This error is thrown in ``Observer_TransactionStatus_InvoiceCreate`` but the root cause is to be found during config initialisation. 
During processing the pending TransactionStatus, the config is first loaded here: \Payone_Core_Model_Service_TransactionStatus_Process::execute:86

In some circumstances the wrong configuration is returned. For example the order is for store-id 2 but the config that is returned is not. The root of the problem seems to be the caching though this pull request will not address any of the caching logic. 
There are no tests and the Configuration is loaded and used in Frontend/ Admin and Cronjob which could lead to a whole lot of side effects when changing something here.

If there are other occasions where the wrong configuration is loaded let me know, maybe it might make sense to change the caching in some way.

So what this pull-request actually does is checking if the config.store-id matches the order.store-id and if not bypassing the config-cache and loading the config for the required store-id fresh and without caching it.

Therefore it introduces an additional parameter ``$useCache`` to the Config Service and the ConfigHelper.
It also uses that in Payone_Core_Model_Service_TransactionStatus_Process::execute when the store-ids mismatch.

Furthermore there is also additional logging in ``Observer_TransactionStatus_InvoiceCreate `` in case the error occurs anyways. The InvoiceCreate Observer also has a fallback implemented. (actually I implemented that one first, but thought it might still come in handy.

We are running this patch in production for a multistore setup and so far havn't had any issues.

To test this you would also need a multistore setup, with different payment methods configured for each store.

To check the logs I used ``cat var/log/payone_cron.log | grep "Process - Config loaded with config.store-id=,"``. This command greps the log for the output introduced in this pull-request. Make sure Payone Cron log is activated in config.