### PR TITLE
Fix for php < 5.6.0

### DIFF
--- a/app/code/community/Payone/Core/Block/Payment/Method/Form/Creditcard.php
+++ b/app/code/community/Payone/Core/Block/Payment/Method/Form/Creditcard.php
@@ -518,8 +518,7 @@ class Payone_Core_Block_Payment_Method_Form_Creditcard
             $cvcLength,
             function ($item) use ($hidden) {
                 return !in_array($item, $hidden);
-            },
-            ARRAY_FILTER_USE_KEY
+            }
         );
 
         return $cvcLength;

--- a/modman
+++ b/modman
@@ -25,3 +25,5 @@ skin/adminhtml/default/default/payone/*                 skin/adminhtml/default/d
 skin/frontend/base/default/payone/*                     skin/frontend/base/default/payone/
 
 skin/frontend/base/default/images/payone/               skin/frontend/base/default/images/payone/
+
+skin/frontend/default/default/payone/*                  skin/frontend/default/default/payone/


### PR DESCRIPTION
Problems with credit card payments and Magento 1.9 on php version < 5.6.0. The credit card input mask doesn't get fully rendered in the checkout and the customers are not able to make purchase.

The php function array_filter only supports the optional flag parameter and constants ARRAY_FILTER_USE_KEY and ARRAY_FILTER_USE_BOTH with php version 5.6.0.
Magento 1.x can also be run on php < 5.6.0.
This fix removes the flag parameter.