### PR TITLE
Fixed AmazonPay checkout for IE10 + IE11

### DIFF
--- a/js/payone/core/amazonpay.js
+++ b/js/payone/core/amazonpay.js
@@ -106,7 +106,7 @@ var PayoneCheckout = {
         }
         this.displayOrderReview(result);
         $('checkoutStepInit').removeClassName('active');
-        $('checkoutStepFinish').classList.add('allow', 'active');
+        $('checkoutStepFinish').addClassName('allow').addClassName('active');
     },
     afterChooseMethod: function (result) {
         this.displayOrderReview(result);


### PR DESCRIPTION
IE10 and IE11 do "[...] not support multiple parameters for the add() & remove() methods" (source https://caniuse.com/#feat=classlist), therefore in checkout review step you can't move further after selecting address + shipping method. This will fix it.