### PR TITLE
Update amazonpay.js

### DIFF
--- a/js/payone/core/amazonpay.js
+++ b/js/payone/core/amazonpay.js
@@ -106,7 +106,8 @@ var PayoneCheckout = {
         }
         this.displayOrderReview(result);
         $('checkoutStepInit').removeClassName('active');
-        $('checkoutStepFinish').classList.add('allow', 'active');
+        $('checkoutStepFinish').classList.add('allow');
+        $('checkoutStepFinish').classList.add('active');
     },
     afterChooseMethod: function (result) {
         this.displayOrderReview(result);


### PR DESCRIPTION
This fixes an issue in IE11 which prevents amazonpay to work properly in IE 11

The error message is: XMLHttpRequest: Network Error 0x2eff, Could not complete the operation due to error 00002eff.