### PR TITLE
Added restrict products extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Related projects can provide additional features and perks that can't be include
 
 * [Pragmatic-Apps/magento1-payone-postponecapture](https://github.com/Pragmatic-Apps/magento1-payone-postponecapture): Provides automatic capture when an order is shipped for Payolution payment methods.
 
+* [Pragmatic-Apps/magento1-payone-restrictproducts](https://github.com/Pragmatic-Apps/magento1-payone-restrictproducts): Extension that allows to automatically disable selected methods when certain products are in the shopping cart. This is necessary to comply with requirements of some payment provides (e.g. when it is not allowed to sell coupons).
+
 ## Contact
 BS PAYONE GmbH<br>
 Office Kiel<br>


### PR DESCRIPTION
We created a little extension that allows to disable selected methods when certain products are in the shopping cart. This is necessary to comply with requirements of some payment provides (e.g. when it is not allowed to sell coupons with installment or the like).