### PR TITLE
Fixed PHP notice "Undefined variable: aRow"

### DIFF
--- a/app/design/adminhtml/default/default/template/payone/core/system/config/form/field/ratepay_shopids.phtml
+++ b/app/design/adminhtml/default/default/template/payone/core/system/config/form/field/ratepay_shopids.phtml
@@ -50,11 +50,11 @@ $_colspan = $_colspan > 1 ? 'colspan="' . $_colspan . '"' : '';
                 ?>
                 <tr id="<?php echo $sId; ?>">
                     <td>
-                        <input type="text" style="width:60px;" class="input-text required-entry" value="<?php echo $aRow['ratepay_shopid']; ?>" name="groups[template_ratepay][fields][ratepay_config][value][<?php echo $sId; ?>][ratepay_shopid]">
+                        <input type="text" style="width:60px;" class="input-text required-entry" value="" name="groups[template_ratepay][fields][ratepay_config][value][<?php echo $sId; ?>][ratepay_shopid]">
                         <span class="required">*</span>
                     </td>
                     <td>
-                        <input type="text" style="width:60px;" class="input-text required-entry" value="<?php echo $aRow['ratepay_currency']; ?>" name="groups[template_ratepay][fields][ratepay_config][value][<?php echo $sId; ?>][ratepay_currency]">
+                        <input type="text" style="width:60px;" class="input-text required-entry" value="" name="groups[template_ratepay][fields][ratepay_config][value][<?php echo $sId; ?>][ratepay_currency]">
                         <span class="required">*</span>
                     </td>
                 </tr>


### PR DESCRIPTION
This change prevents Magento/PHP outputting or logging

> Notice: Undefined variable: aRow  in /var/www/html/app/design/adminhtml/default/default/template/payone/core/system/config/form/field/ratepay_shopids.phtml on line 53
