### PR TITLE
leave the input value empty

### DIFF
--- a/app/design/adminhtml/default/default/template/payone/core/system/config/form/field/ratepay_direct_debit_shopids.phtml
+++ b/app/design/adminhtml/default/default/template/payone/core/system/config/form/field/ratepay_direct_debit_shopids.phtml
@@ -50,11 +50,11 @@ $_colspan = $_colspan > 1 ? 'colspan="' . $_colspan . '"' : '';
                 ?>
                 <tr id="<?php echo $sId; ?>">
                     <td>
-                        <input type="text" style="width:60px;" class="input-text required-entry" value="<?php echo $aRow['ratepay_shopid']; ?>" name="groups[template_ratepay_direct_debit][fields][ratepay_config][value][<?php echo $sId; ?>][ratepay_shopid]">
+                        <input type="text" style="width:60px;" class="input-text required-entry" value="" name="groups[template_ratepay_direct_debit][fields][ratepay_config][value][<?php echo $sId; ?>][ratepay_shopid]">
                         <span class="required">*</span>
                     </td>
                     <td>
-                        <input type="text" style="width:60px;" class="input-text required-entry" value="<?php echo $aRow['ratepay_currency']; ?>" name="groups[template_ratepay_direct_debit][fields][ratepay_config][value][<?php echo $sId; ?>][ratepay_currency]">
+                        <input type="text" style="width:60px;" class="input-text required-entry" value="" name="groups[template_ratepay_direct_debit][fields][ratepay_config][value][<?php echo $sId; ?>][ratepay_currency]">
                         <span class="required">*</span>
                     </td>
                 </tr>


### PR DESCRIPTION
I think there are no items in the array, so the value should be empty - this could be a fix for: https://github.com/PAYONE-GmbH/magento-1/issues/377 but I have not tested the code