### PR TITLE
MAGE-464: Introduce mechanism to retry amazonpay order placement

### DIFF
--- a/app/code/community/Payone/Core/Model/Config/General.php
+++ b/app/code/community/Payone/Core/Model/Config/General.php
@@ -56,6 +56,10 @@ class Payone_Core_Model_Config_General extends Payone_Core_Model_Config_AreaAbst
      * @var Payone_Core_Model_Config_General_PaymentPaydirektExpressCheckout
      */
     protected $payment_paydirekt_express_checkout;
+    /**
+     * @var Payone_Core_Model_Config_General_PaymentAmazonPayCheckout
+     */
+    protected $payment_amazon_pay_checkout;
 
     /**
      * @var Payone_Core_Model_Config_General_ParameterNarrativeText
@@ -189,5 +193,21 @@ class Payone_Core_Model_Config_General extends Payone_Core_Model_Config_AreaAbst
     public function getParameterNarrativeText()
     {
         return $this->parameter_narrative_text;
+    }
+
+    /**
+     * @param Payone_Core_Model_Config_General_PaymentAmazonPayCheckout $payment_amazon_pay_checkout
+     */
+    public function setPaymentAmazonPayCheckout($payment_amazon_pay_checkout)
+    {
+        $this->payment_amazon_pay_checkout = $payment_amazon_pay_checkout;
+    }
+
+    /**
+     * @return Payone_Core_Model_Config_General_PaymentAmazonPayCheckout
+     */
+    public function getPaymentAmazonPayCheckout()
+    {
+        return $this->payment_amazon_pay_checkout;
     }
 }

--- a/app/code/community/Payone/Core/Model/Config/General/PaymentAmazonPayCheckout.php
+++ b/app/code/community/Payone/Core/Model/Config/General/PaymentAmazonPayCheckout.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the GNU General Public License (GPL 3)
+ * that is bundled with this package in the file LICENSE.txt
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade Payone_Core to newer
+ * versions in the future. If you wish to customize Payone_Core for your
+ * needs please refer to http://www.payone.de for more information.
+ *
+ * @category        Payone
+ * @package         Payone_Core_Model
+ * @subpackage      Config_General
+ * @copyright       Copyright (c) 2019 <kontakt@fatchip.de> - www.fatchip.com
+ * @author          Vincent Boulanger <vincent.boulanger@fatchip.de>
+ * @license         <http://www.gnu.org/licenses/> GNU General Public License (GPL 3)
+ * @link            http://www.fatchip.com
+ */
+class Payone_Core_Model_Config_General_PaymentAmazonPayCheckout extends Payone_Core_Model_Config_AreaAbstract
+{
+    /**
+     * @var int
+     */
+    protected $amazon_pay_checkout_retries = 1;
+
+    /**
+     * @return int
+     */
+    public function getAmazonPayCheckoutRetries()
+    {
+        return $this->amazon_pay_checkout_retries;
+    }
+
+    /**
+     * @param int $amazon_pay_checkout_retries
+     */
+    public function setAmazonPayCheckoutRetries($amazon_pay_checkout_retries)
+    {
+        $this->amazon_pay_checkout_retries = $amazon_pay_checkout_retries;
+    }
+}

--- a/app/code/community/Payone/Core/Model/Service/Amazon/Pay/Checkout.php
+++ b/app/code/community/Payone/Core/Model/Service/Amazon/Pay/Checkout.php
@@ -353,6 +353,7 @@ class Payone_Core_Model_Service_Amazon_Pay_Checkout
                 $service->submitAll();
                 $remainingAttempts = 0;
             } catch (\Exception $e) {
+                Mage::logException($e);
                 if ($remainingAttempts == 0 || !($e instanceof Zend_Db_Statement_Exception)) {
                     if (in_array($e->getCode(), [981, 985, 986])) { // send to widgets
                         $session->setData('amazon_lock_order', true);

--- a/app/code/community/Payone/Core/etc/system.xml
+++ b/app/code/community/Payone/Core/etc/system.xml
@@ -710,6 +710,25 @@
                         </paydirekt_express_checkout_image>
                     </fields>
                 </payment_paydirekt_express_checkout>
+                <payment_amazon_pay_checkout>
+                    <label>Payment AmazonPay Checkout</label>
+                    <frontend_type>text</frontend_type>
+                    <sort_order>130</sort_order>
+                    <show_in_default>1</show_in_default>
+                    <show_in_website>1</show_in_website>
+                    <show_in_store>1</show_in_store>
+                    <fields>
+                        <amazon_pay_checkout_retries translate="label,comment">
+                            <label>Maximum attempts of order placement</label>
+                            <comment>How many times should the order placement be retried in case of database error.</comment>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>10</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </amazon_pay_checkout_retries>
+                    </fields>
+                </payment_amazon_pay_checkout>
             </groups>
         </payone_general>
 


### PR DESCRIPTION
+ only in case of DB exception (should cover the DBlock exception cases)
+ the value is configurable into admin Payone->General
+ any invalid/missing value will result into a 1 (meaning only one try, as it is before this change)