### PR TITLE
MAGE-470: Fix aborted Amazon Pay checkouts

### DIFF
--- a/app/code/community/Payone/Core/Model/Service/Amazon/Pay/Checkout.php
+++ b/app/code/community/Payone/Core/Model/Service/Amazon/Pay/Checkout.php
@@ -177,7 +177,11 @@ class Payone_Core_Model_Service_Amazon_Pay_Checkout
         $layout->removeOutputBlock('checkout_review_submit');
         $layout->generateXml()->generateBlocks();
         $orderReviewHtml = $layout->getOutput();
-        $this->checkoutSession->setPayoneGenericpaymentGrandTotal($this->quote->getGrandTotal()); // MAGE-374: Force the total to be stored in session for further check
+        
+        //convert the float value to a formatted string to avoind float rounding issues
+        $quoteGrandTotal = number_format($this->quote->getGrandTotal(), 4);
+        
+        $this->checkoutSession->setPayoneGenericpaymentGrandTotal($quoteGrandTotal); // MAGE-374: Force the total to be stored in session for further check
         if ($shippingRatesCount === 1) {
             $params['shippingMethodCode'] = array_values($shippingRates)[0][0]['code'];
             if ($this->quote->getShippingAddress()->getShippingMethod() !== $params['shippingMethodCode']) {
@@ -333,8 +337,12 @@ class Payone_Core_Model_Service_Amazon_Pay_Checkout
         /** @var \Payone_Core_Model_Session $session */
         $session = Mage::getSingleton('payone_core/session');
         $amazonOrderReferenceId = $session->getData('amazon_reference_id');
+        
+        //compare the values with the same string format to avoid strange float rounding issues
+        $quoteGrandTotal    = number_format($this->quote->getGrandTotal(), 4);
+        $sessionGrandTotal  = number_format($this->checkoutSession->getPayoneGenericpaymentGrandTotal(), 4);
 
-        if ($this->quote->getGrandTotal() != $this->checkoutSession->getPayoneGenericpaymentGrandTotal()) {
+        if ($quoteGrandTotal != $sessionGrandTotal) {
             // The basket was changed - abort current checkout
             $text = 'Sorry, your transaction with Amazon Pay was not successful. Please try again.';
             return $this->cancelAmazonPayment($session, $text);

--- a/app/code/community/Payone/Core/Model/Service/Amazon/Pay/Checkout.php
+++ b/app/code/community/Payone/Core/Model/Service/Amazon/Pay/Checkout.php
@@ -339,8 +339,19 @@ class Payone_Core_Model_Service_Amazon_Pay_Checkout
         $amazonOrderReferenceId = $session->getData('amazon_reference_id');
         
         //compare the values with the same string format to avoid strange float rounding issues
-        $quoteGrandTotal    = number_format($this->quote->getGrandTotal(), 4);
-        $sessionGrandTotal  = number_format($this->checkoutSession->getPayoneGenericpaymentGrandTotal(), 4);
+        $quoteGrandTotal    = number_format(
+            $this->quote->getGrandTotal(),
+            4,
+            '.',
+            ''
+        );
+
+        $sessionGrandTotal  = number_format(
+            $this->checkoutSession->getPayoneGenericpaymentGrandTotal(),
+            4,
+            '.',
+            ''
+        );
 
         if ($quoteGrandTotal != $sessionGrandTotal) {
             // The basket was changed - abort current checkout

--- a/app/code/community/Payone/Core/Model/Service/Amazon/Pay/Checkout.php
+++ b/app/code/community/Payone/Core/Model/Service/Amazon/Pay/Checkout.php
@@ -353,7 +353,13 @@ class Payone_Core_Model_Service_Amazon_Pay_Checkout
             ''
         );
 
-        if ($quoteGrandTotal != $sessionGrandTotal) {
+        
+        //check the difference between the values
+        $difference = abs((float) $quoteGrandTotal - (float) $sessionGrandTotal);
+
+        //@todo: add a feature toggle to the config for the 1 cent rounding tolerance
+        //if the values are different and the difference is more than one cent (rounding issue) => cancel the payment
+        if ($quoteGrandTotal != $sessionGrandTotal && $difference > 0.01) { 
             // The basket was changed - abort current checkout
             $text = 'Sorry, your transaction with Amazon Pay was not successful. Please try again.';
             return $this->cancelAmazonPayment($session, $text);

--- a/app/code/community/Payone/Core/Model/Service/Amazon/Pay/Checkout.php
+++ b/app/code/community/Payone/Core/Model/Service/Amazon/Pay/Checkout.php
@@ -179,7 +179,7 @@ class Payone_Core_Model_Service_Amazon_Pay_Checkout
         $orderReviewHtml = $layout->getOutput();
         
         //convert the float value to a formatted string to avoind float rounding issues
-        $quoteGrandTotal = number_format($this->quote->getGrandTotal(), 4);
+        $quoteGrandTotal = number_format($this->quote->getGrandTotal(), 4, '.', '');
         
         $this->checkoutSession->setPayoneGenericpaymentGrandTotal($quoteGrandTotal); // MAGE-374: Force the total to be stored in session for further check
         if ($shippingRatesCount === 1) {


### PR DESCRIPTION
Under some circumstances, there is the error "Sorry, your transaction with Amazon Pay was not successful. Please try again." thrown, even if the values seem to be identical. After implementing a logging, we figured out, that there seems to be a comparison between a string and a floating point number, which is not safe anyway. See: https://stackoverflow.com/questions/3148937/compare-floats-in-php

To avoid this, the value is converted to a string before writing the value into the session and to convert both values to the same "number_format" value with 4 digits