### PR TITLE
eliminated another (seldom) rounding issue

### DIFF
--- a/app/code/community/Payone/Core/Model/Service/Amazon/Pay/Checkout.php
+++ b/app/code/community/Payone/Core/Model/Service/Amazon/Pay/Checkout.php
@@ -352,14 +352,19 @@ class Payone_Core_Model_Service_Amazon_Pay_Checkout
             '.',
             ''
         );
-
         
         //check the difference between the values
-        $difference = abs((float) $quoteGrandTotal - (float) $sessionGrandTotal);
+        //calculate the difference in cents to avoid rounding issues again
+        //
+        // => using floats is evil try that:
+
+        //php > echo abs((float) '244.68' - (float) '244.67');
+        // => output: 0.010000000000019
+        $difference = number_format(abs((float) $quoteGrandTotal - (float) $sessionGrandTotal), 2) * 100;
 
         //@todo: add a feature toggle to the config for the 1 cent rounding tolerance
         //if the values are different and the difference is more than one cent (rounding issue) => cancel the payment
-        if ($quoteGrandTotal != $sessionGrandTotal && $difference > 0.01) { 
+        if ($quoteGrandTotal != $sessionGrandTotal && $difference > 1) {
             // The basket was changed - abort current checkout
             $text = 'Sorry, your transaction with Amazon Pay was not successful. Please try again.';
             return $this->cancelAmazonPayment($session, $text);

--- a/app/code/community/Payone/Core/Model/Service/Amazon/Pay/Checkout.php
+++ b/app/code/community/Payone/Core/Model/Service/Amazon/Pay/Checkout.php
@@ -484,8 +484,9 @@ class Payone_Core_Model_Service_Amazon_Pay_Checkout
             $this->quote->getGrandTotal()
         );
         $this->checkCurrencyConversion($request);
-
-        $this->checkoutSession->setPayoneGenericpaymentGrandTotal($this->quote->getGrandTotal());
+        
+        $quoteGrandTotal    = number_format($this->quote->getGrandTotal(), 4, '.', '');
+        $this->checkoutSession->setPayoneGenericpaymentGrandTotal($quoteGrandTotal);
 
         return $this->getFactory()->getServiceApiPaymentGenericpayment()->request($request);
     }


### PR DESCRIPTION
The difference calculation should be based on "rounded" values and total cents, to avoid a seldom rounding issue discovered from our logging. See comment in the code and try it yourself. I'm not sure if there is a cleaner way to do the calculation.

Try:
```
php > echo (number_format(abs((float) '244.68' - (float) '244.67'), 2) > 0.01);

php > echo (number_format(abs((float) '244.68' - (float) '244.66'), 2) > 0.01);
```