### PR TITLE
item qtys doubled when using multi tabs and redirect payments

### DIFF
--- a/app/code/community/Payone/Core/Model/Handler/Cancellation.php
+++ b/app/code/community/Payone/Core/Model/Handler/Cancellation.php
@@ -85,6 +85,7 @@ class Payone_Core_Model_Handler_Cancellation extends Payone_Core_Model_Handler_A
                 $oOldQuote = $this->getFactory()->getModelSalesQuote();
                 $oOldQuote->load($quoteId);
                 if ($oOldQuote && $oOldQuote->getId()) {
+                    $oQuote->removeAllItems();
                     $oQuote->merge($oOldQuote);
                     $oQuote->collectTotals();
                     $oQuote->save();


### PR DESCRIPTION
If a post-checkout redirect payment is neither completed nor truly cancelled, use of another browser tab in the shop has all item quantities in the cart doubled.
This issue was found using _online_bank_transfer_p24_ but I believe it can apply to any payment that redirects after completing the checkout, such as Paypal 

to reproduce:
    - go to a PDP page and add the product to cart
    - open the PDP page in another tab in the same browser
    - with either tab complete the magento checkout with a post checkout payment selected (ex: Przelewy24)
    - redirect to the payment site, but do not complete the payment yet
    - switch to the other tab and continue to shop. The minicart might not reflect this right away, but if you refresh or add another product, all the cart items will have double the original cart quantities.

provided simple fix:
- normally in \Payone_Core_Model_Handler_Cancellation::handle(88) the session quote items are already removed, but not when triggered through the above scenario. Manually removing any items seems to fix this problem without interfering with intended functionality. 

this doesn't change the issue of the customer being able to switch back to the payment tab and completing the purchase, thus having a completed payment on a cancelled order. but that is not in this scope ;-)