### PR TITLE
#478 Fix JavaScript "Uncaught TypeError: Cannot read properties of null (reading 'getValue')"

### DIFF
--- a/app/design/frontend/base/default/template/payone/core/payment/method/form/ratepay.phtml
+++ b/app/design/frontend/base/default/template/payone/core/payment/method/form/ratepay.phtml
@@ -203,8 +203,8 @@ $sDeviceIdentId = $this->getRatePayDeviceFingerprintSnippetId();
                                class="validate-sepa-bic input-text"
                                value="<?php echo $this->getSavedCustomerData('payone_sepa_bic');?>"
                                autocomplete="off" maxlength="11"
-                               onchange="inputToUppaerCaseAndNumbers(this); blockPaymentMethodInputs('<?php echo $code ?>', <?php echo $configShowBankData; ?>);"
-                               oninput="inputToUppaerCaseAndNumbers(this); blockPaymentMethodInputs('<?php echo $code ?>', <?php echo $configShowBankData; ?>);"/>
+                               onchange="inputToUppaerCaseAndNumbers(this)"
+                               oninput="inputToUppaerCaseAndNumbers(this)"/>
                     </div>
                 </li>
             <?php endif; ?>

--- a/app/design/frontend/base/default/template/payone/core/payment/method/form/ratepay_direct_debit.phtml
+++ b/app/design/frontend/base/default/template/payone/core/payment/method/form/ratepay_direct_debit.phtml
@@ -110,8 +110,8 @@ $sDeviceIdentId = $this->getRatePayDeviceFingerprintSnippetId();
                        class="validate-sepa-bic input-text"
                        value="<?php echo $this->getSavedCustomerData('payone_sepa_bic');?>"
                        autocomplete="off" maxlength="11"
-                       onchange="inputToUppaerCaseAndNumbers(this); blockPaymentMethodInputs('<?php echo $code ?>', <?php echo $configShowBankData; ?>);"
-                       oninput="inputToUppaerCaseAndNumbers(this); blockPaymentMethodInputs('<?php echo $code ?>', <?php echo $configShowBankData; ?>);"/>
+                       onchange="inputToUppaerCaseAndNumbers(this)"
+                       oninput="inputToUppaerCaseAndNumbers(this)"/>
             </div>
         </li>
 
@@ -149,7 +149,7 @@ $sDeviceIdentId = $this->getRatePayDeviceFingerprintSnippetId();
                             </option>
                         <?php endfor; ?>
                     </select>
-                    
+
                     <input type="hidden" id="<?php echo $code ?>_additional_fields_customer_dob_full"
                             name="payment[payone_customer_dob]" class="validate-18-years">
                 </div>


### PR DESCRIPTION
This will fix the JavaScript error (described in #478) which occurs when typing in ratepay's or ratepay_direct_debit's BIC field. There are no bank code or account number fields for those two payment methods.