### PR TITLE
Fix transaction status collection not filtered very efficiently

### DIFF
--- a/app/code/community/Payone/Core/controllers/TransactionStatusController.php
+++ b/app/code/community/Payone/Core/controllers/TransactionStatusController.php
@@ -82,11 +82,11 @@ class Payone_Core_TransactionStatusController extends Payone_Core_Controller_Abs
             /**
              * MAGE-536 : Fix missing OrderId and StoreId in TxStatus when reference exists
              */
-            if ($response->getStatus() == 'TSOK') {
+            if ($response->getStatus() == 'TSOK' && ! empty($reference)) {
                 /** @var $transactionStatusCollection Payone_Core_Model_Domain_Resource_Protocol_TransactionStatus_Collection */
                 $transactionStatusCollection = Mage::getModel('payone_core/domain_protocol_transactionStatus')
-                    ->getCollection();
-                $transactionStatusCollection->getItemsByColumnValue('reference', $reference);
+                    ->getCollection()
+                    ->addFieldToFilter('reference', $reference);
 
                 /** @var Payone_Core_Model_Domain_Protocol_TransactionStatus $transactionStatus */
                 foreach ($transactionStatusCollection as $transactionStatus) {


### PR DESCRIPTION
This PR fixes a huge performance drawback introduced by the change in [5231b7ff](https://github.com/PAYONE-GmbH/magento-1/commit/5231b7ff549d6ef67ca711d413253f50f802bf61) in the transaction status controller.

The issue is caused by the fact that the collection is not filtered on database level resulting in **all** status entries being loaded.

