### PR TITLE
Fix order canceling when order is in tx status failed

### DIFF
--- a/app/code/community/Payone/Core/Model/Payment/Method/Abstract.php
+++ b/app/code/community/Payone/Core/Model/Payment/Method/Abstract.php
@@ -172,8 +172,8 @@ abstract class Payone_Core_Model_Payment_Method_Abstract
     {
         $status = $payment->getOrder()->getPayoneTransactionStatus();
         $session = Mage::getModel('payone_core/session');
-
-        if (empty($status) or $status == 'REDIRECT') {
+	
+	if (empty($status) or in_array($status,['REDIRECT','failed'])) {
             return $this; // Don´t send cancel to PAYONE on orders without TxStatus
         }
 


### PR DESCRIPTION
According the payone documentation for an order in tx status "failed" no further actions are possible.

![image](https://github.com/user-attachments/assets/e5202e71-bfc3-45d0-b783-75037ab5c4bf)

A failed order can not be canceled, as a 0.0 amount capture is happening, so the attempt needs to be skipped from my current understanding.

![image](https://github.com/user-attachments/assets/c80aef68-f749-459d-9ab6-105529b6370b)


This fix skips the capture when order is in failed tx status.

Please check and reply.

